### PR TITLE
Add Rust CLI for building rocm-cmake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rocm-build"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "4.4.8", features = ["derive"] }
+anyhow = "1.0.75"
+log = "0.4.20"
+env_logger = "0.10.0"
+glob = "0.3.1"

--- a/src/build_logic.rs
+++ b/src/build_logic.rs
@@ -1,0 +1,140 @@
+use anyhow::{Context, Result, anyhow};
+use log::{info, warn, debug};
+use std::path::Path;
+use std::process::Command;
+use std::fs;
+
+use crate::config::Config;
+use crate::utils::{run_command, find_cmake_projects, copy_if_selected, SelectedPurpose};
+
+fn run_cmake_configure(config: &Config, project_path: &Path, build_dir: &Path) -> Result<()> {
+    let cmake_source_dir = project_path;
+    let mut cmake_cmd = Command::new("cmake");
+    cmake_cmd.arg(format!("-S{}", cmake_source_dir.display()));
+    cmake_cmd.arg(format!("-B{}", build_dir.display()));
+    cmake_cmd.arg(format!("-DCMAKE_BUILD_TYPE=Release")); // TODO: Make configurable
+
+    if let Some(install_dir) = &config.install_dir {
+        cmake_cmd.arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()));
+    }
+
+    // Add rocm-cmake path for other projects to find it
+    // This assumes that rocm-cmake itself doesn't need this when being built.
+    if project_path != config.rocm_cmake_path {
+         cmake_cmd.arg(format!("-Drocm-cmake_DIR={}", config.rocm_cmake_path.join("build").display()));
+    }
+
+
+    info!(
+        "Configuring project: {} with build dir: {}",
+        project_path.file_name().unwrap_or_default().to_string_lossy(),
+        build_dir.display()
+    );
+    debug!("CMake configure command: {:?}", cmake_cmd);
+
+    run_command(cmake_cmd, "CMake configuration")
+}
+
+fn run_cmake_build(build_dir: &Path) -> Result<()> {
+    let mut cmake_cmd = Command::new("cmake");
+    cmake_cmd.arg("--build").arg(build_dir);
+    cmake_cmd.arg("--config").arg("Release"); // TODO: Make configurable
+    cmake_cmd.arg("--").arg("-j"); // Parallel build
+
+    info!("Building project in: {}", build_dir.display());
+    debug!("CMake build command: {:?}", cmake_cmd);
+    run_command(cmake_cmd, "CMake build")
+}
+
+fn run_cmake_install(build_dir: &Path) -> Result<()> {
+    let mut cmake_cmd = Command::new("cmake");
+    cmake_cmd.arg("--install").arg(build_dir);
+    cmake_cmd.arg("--config").arg("Release"); // TODO: Make configurable
+
+    info!("Installing project from: {}", build_dir.display());
+    debug!("CMake install command: {:?}", cmake_cmd);
+    run_command(cmake_cmd, "CMake install")
+}
+
+pub fn run_build(config: &Config) -> Result<()> {
+    info!("Starting build process...");
+
+    // 1. Build rocm-cmake first if it's implicitly or explicitly targeted
+    //    or if no specific packages are given (build all)
+    let build_rocm_cmake_first = config.packages.is_empty() ||
+                               config.packages.iter().any(|p| p == "rocm-cmake" || p == "rocm-cmake/");
+    
+    if build_rocm_cmake_first {
+        info!("Processing rocm-cmake first...");
+        let rocm_cmake_build_dir = config.get_package_build_dir("rocm-cmake");
+        fs::create_dir_all(&rocm_cmake_build_dir).with_context(|| format!("Failed to create build directory for rocm-cmake: {}", rocm_cmake_build_dir.display()))?;
+
+        run_cmake_configure(config, &config.rocm_cmake_path, &rocm_cmake_build_dir)
+            .with_context(|| format!("CMake configuration failed for rocm-cmake at {}", config.rocm_cmake_path.display()))?;
+        run_cmake_build(&rocm_cmake_build_dir)
+            .with_context(|| format!("CMake build failed for rocm-cmake in {}", rocm_cmake_build_dir.display()))?;
+        if config.install_dir.is_some() {
+            // Install rocm-cmake to its own subdir within the main install_dir
+            let rocm_cmake_install_dir_specific = config.get_package_install_dir("rocm-cmake");
+             if let Some(idir) = rocm_cmake_install_dir_specific {
+                let mut install_cmd = Command::new("cmake");
+                install_cmd.arg("--install").arg(&rocm_cmake_build_dir);
+                install_cmd.arg("--config").arg("Release");
+                install_cmd.arg("--prefix").arg(idir); // Install rocm-cmake to its own folder
+                info!("Installing rocm-cmake to: {}", idir.display());
+                debug!("CMake install command for rocm-cmake: {:?}", install_cmd);
+                run_command(install_cmd, "CMake install for rocm-cmake")?;
+            }
+        }
+        info!("rocm-cmake processed successfully.");
+    } else {
+        info!("Skipping rocm-cmake build as it's not explicitly targeted and other packages are specified.");
+        // Ensure the build directory for rocm-cmake exists if other projects need it.
+        // This is crucial if rocm-cmake was pre-built or is available through other means.
+        let rocm_cmake_build_path = config.rocm_cmake_path.join("build");
+        if !rocm_cmake_build_path.exists() {
+             warn!("rocm-cmake build directory ({}) not found. Other projects might fail if they depend on it.", rocm_cmake_build_path.display());
+        }
+    }
+
+
+    // 2. Find other CMake projects in the source directory (excluding rocm-cmake itself)
+    let projects = find_cmake_projects(&config.source_dir, Some(&config.rocm_cmake_path))?;
+    if projects.is_empty() && config.packages.iter().any(|p| p != "rocm-cmake") {
+         warn!("No other CMake projects found in {}", config.source_dir.display());
+    } else if projects.is_empty() && config.packages.is_empty() {
+        info!("No other CMake projects found besides rocm-cmake. Build process might be targeting rocm-cmake only or the source directory is empty.");
+    }
+
+
+    for project_path in projects {
+        let project_name = project_path.file_name().unwrap_or_default().to_string_lossy().to_string();
+
+        if !copy_if_selected(&config.packages, &project_name, SelectedPurpose::Build) {
+            info!("Skipping project {} as it's not in the selected packages for build.", project_name);
+            continue;
+        }
+        
+        info!("Processing project: {}", project_name);
+        let project_build_dir = config.get_package_build_dir(&project_name);
+        fs::create_dir_all(&project_build_dir).with_context(|| format!("Failed to create build directory for {}: {}", project_name, project_build_dir.display()))?;
+
+        run_cmake_configure(config, &project_path, &project_build_dir)
+            .with_context(|| format!("CMake configuration failed for {} at {}", project_name, project_path.display()))?;
+        run_cmake_build(&project_build_dir)
+            .with_context(|| format!("CMake build failed for {} in {}", project_name, project_build_dir.display()))?;
+
+        if config.install_dir.is_some() {
+            run_cmake_install(&project_build_dir)
+                .with_context(|| format!("CMake install failed for {} from {}", project_name, project_build_dir.display()))?;
+        }
+        info!("Successfully processed project: {}", project_name);
+    }
+
+    if config.packages.is_empty() && !build_rocm_cmake_first && projects.is_empty() {
+        info!("No packages specified and no projects found (rocm-cmake was not built in this run). Nothing to do.");
+    } else {
+        info!("Build process completed.");
+    }
+    Ok(())
+}

--- a/src/clean_logic.rs
+++ b/src/clean_logic.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context, Result};
+use log::{info, warn};
+use std::fs;
+
+use crate::config::Config;
+use crate::utils::{find_cmake_projects, copy_if_selected, SelectedPurpose};
+
+pub fn run_clean(config: &Config) -> Result<()> {
+    info!("Starting clean process...");
+
+    // Determine which packages to clean
+    let all_projects_in_src: Vec<String> = find_cmake_projects(&config.source_dir, None)?
+        .iter()
+        .map(|p| p.file_name().unwrap_or_default().to_string_lossy().into_owned())
+        .collect();
+    
+    let mut packages_to_clean = Vec::new();
+    if config.packages.is_empty() {
+        // If no specific packages, clean all found projects + rocm-cmake
+        packages_to_clean = all_projects_in_src;
+        if !packages_to_clean.iter().any(|p| p == "rocm-cmake") {
+             packages_to_clean.push("rocm-cmake".to_string()); // Ensure rocm-cmake is included
+        }
+    } else {
+        // Clean only specified packages
+        for pkg_name in &config.packages {
+            // Normalize package name (e.g., remove trailing slash)
+            let normalized_name = pkg_name.trim_end_matches('/').to_string();
+            if all_projects_in_src.contains(&normalized_name) || normalized_name == "rocm-cmake" {
+                if !packages_to_clean.contains(&normalized_name) {
+                    packages_to_clean.push(normalized_name);
+                }
+            } else {
+                warn!("Specified package '{}' not found as a CMake project in source or as 'rocm-cmake'. Skipping its clean.", pkg_name);
+            }
+        }
+    }
+    
+    if packages_to_clean.is_empty() && !config.packages.is_empty() {
+        warn!("No valid packages selected for cleaning based on input and found projects.");
+        return Ok(());
+    } else if packages_to_clean.is_empty() {
+        info!("No packages found to clean.");
+        return Ok(());
+    }
+
+    info!("Targeting the following packages for cleaning: {:?}", packages_to_clean);
+
+    for package_name in &packages_to_clean {
+        // Clean build directory for the package
+        let package_build_dir = config.get_package_build_dir(package_name);
+        if package_build_dir.exists() {
+            info!("Removing build directory for {}: {}", package_name, package_build_dir.display());
+            fs::remove_dir_all(&package_build_dir)
+                .with_context(|| format!("Failed to remove build directory for {}: {}", package_name, package_build_dir.display()))?;
+        } else {
+            info!("Build directory for {} not found, skipping: {}", package_name, package_build_dir.display());
+        }
+
+        // Clean install directory for the package (if install_dir is set)
+        if let Some(package_install_dir) = config.get_package_install_dir(package_name) {
+            if package_install_dir.exists() {
+                info!("Removing install directory for {}: {}", package_name, package_install_dir.display());
+                fs::remove_dir_all(&package_install_dir)
+                    .with_context(|| format!("Failed to remove install directory for {}: {}", package_name, package_install_dir.display()))?;
+            } else {
+                info!("Install directory for {} not found, skipping: {}", package_name, package_install_dir.display());
+            }
+        }
+    }
+    
+    // If config.packages is empty (meaning clean all), also try to remove the top-level build_dir and install_dir
+    // but only if they are empty after cleaning individual packages.
+    if config.packages.is_empty() {
+        if config.build_dir.exists() && fs::read_dir(&config.build_dir)?.next().is_none() {
+            info!("Removing top-level build directory: {}", config.build_dir.display());
+            fs::remove_dir(&config.build_dir).with_context(|| format!("Failed to remove top-level build directory {}", config.build_dir.display()))?;
+        }
+        if let Some(ref idir) = config.install_dir {
+            if idir.exists() && fs::read_dir(idir)?.next().is_none() {
+                info!("Removing top-level install directory: {}", idir.display());
+                fs::remove_dir(idir).with_context(|| format!("Failed to remove top-level install directory {}", idir.display()))?;
+            }
+        }
+    }
+
+
+    info!("Clean process completed.");
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,122 @@
+use anyhow::{Context, Result, anyhow};
+use clap::{Parser, Subcommand};
+use log::debug;
+use std::path::{Path, PathBuf};
+use std::fs;
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    #[arg(short, long, value_name = "DIR", default_value = "./build", help = "Directory for build artifacts")]
+    pub build_dir: PathBuf,
+
+    #[arg(short, long, value_name = "DIR", help = "Optional installation directory for built packages")]
+    pub install_dir: Option<PathBuf>,
+
+    #[arg(short, long, value_name = "PACKAGE", help = "Specific packages to target (comma-separated or multiple times)")]
+    pub packages: Vec<String>,
+
+    #[arg(long, default_value_t = false, help = "Enable verbose output")]
+    pub verbose: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Commands {
+    /// Builds the specified ROCm packages
+    Build,
+    /// Cleans the build and (optionally) install directories
+    Clean,
+    /// Prints the output directory for specified packages
+    Outdir {
+        #[arg(required = true, value_name = "PACKAGE", help = "Specific packages to get output directory for (comma-separated or multiple times)")]
+        packages: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub build_dir: PathBuf,
+    pub install_dir: Option<PathBuf>,
+    pub packages: Vec<String>,
+    pub rocm_cmake_path: PathBuf,
+    pub source_dir: PathBuf, // Root of the rocm-cmake checkout
+}
+
+impl Config {
+    pub fn from_cli(cli: Cli) -> Result<Self> {
+        let current_dir = std::env::current_dir().context("Failed to get current directory")?;
+        
+        let build_dir = if cli.build_dir.is_absolute() {
+            cli.build_dir
+        } else {
+            current_dir.join(cli.build_dir)
+        };
+        debug!("Resolved build directory: {}", build_dir.display());
+
+        let install_dir = cli.install_dir.map(|p| {
+            if p.is_absolute() {
+                p
+            } else {
+                current_dir.join(p)
+            }
+        });
+        if let Some(ref idir) = install_dir {
+            debug!("Resolved install directory: {}", idir.display());
+        }
+
+        // Assuming rocm-cmake is in the current directory or a subdirectory
+        // A more robust solution might involve searching or a config file
+        let source_dir = current_dir.clone();
+        let rocm_cmake_path = source_dir.join("rocm-cmake"); 
+        if !rocm_cmake_path.exists() || !rocm_cmake_path.is_dir() {
+            // Attempt to find rocm-cmake in parent directories up to a certain limit
+            let mut search_dir = current_dir.clone();
+            let mut found_rocm_cmake = false;
+            for _ in 0..5 { // Limit search depth
+                if search_dir.join("rocm-cmake").is_dir() {
+                    rocm_cmake_path = search_dir.join("rocm-cmake");
+                    source_dir = search_dir;
+                    found_rocm_cmake = true;
+                    break;
+                }
+                if let Some(parent) = search_dir.parent() {
+                    search_dir = parent.to_path_buf();
+                } else {
+                    break;
+                }
+            }
+            if !found_rocm_cmake {
+                 return Err(anyhow!("'rocm-cmake' directory not found in current or parent directories. Please run from the root of the rocm-cmake project or ensure it's a subdirectory."));
+            }
+        }
+        debug!("Determined source directory: {}", source_dir.display());
+        debug!("Using rocm-cmake path: {}", rocm_cmake_path.display());
+
+
+        fs::create_dir_all(&build_dir)
+            .with_context(|| format!("Failed to create build directory: {}", build_dir.display()))?;
+        if let Some(ref idir) = install_dir {
+            fs::create_dir_all(idir)
+                .with_context(|| format!("Failed to create install directory: {}", idir.display()))?;
+        }
+
+        Ok(Config {
+            build_dir,
+            install_dir,
+            packages: cli.packages,
+            rocm_cmake_path,
+            source_dir,
+        })
+    }
+
+    pub fn get_package_build_dir(&self, package_name: &str) -> PathBuf {
+        self.build_dir.join(package_name)
+    }
+
+    pub fn get_package_install_dir(&self, package_name: &str) -> Option<PathBuf> {
+        self.install_dir.as_ref().map(|idir| idir.join(package_name))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use clap::Parser;
+use env_logger::Env;
+use log::{info, error};
+
+mod build_logic;
+mod clean_logic;
+mod config;
+mod outdir_logic;
+mod utils;
+
+use config::{Cli, Commands, Config};
+
+fn main() -> Result<()> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+
+    let cli = Cli::parse();
+
+    let config = match Config::from_cli(cli.clone()) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            error!("Configuration error: {}", e);
+            return Err(e);
+        }
+    };
+
+    info!("ROCm Build Tool");
+    info!("Build Directory: {}", config.build_dir.display());
+    if let Some(install_dir) = &config.install_dir {
+        info!("Install Directory: {}", install_dir.display());
+    }
+    if !config.packages.is_empty() {
+        info!("Target Packages: {:?}", config.packages);
+    }
+
+
+    match cli.command {
+        Commands::Build => {
+            info!("Executing build command...");
+            if let Err(e) = build_logic::run_build(&config) {
+                error!("Build failed: {}", e);
+                return Err(e);
+            }
+            info!("Build completed successfully.");
+        }
+        Commands::Clean => {
+            info!("Executing clean command...");
+            if let Err(e) = clean_logic::run_clean(&config) {
+                error!("Clean failed: {}", e);
+                return Err(e);
+            }
+            info!("Clean completed successfully.");
+        }
+        Commands::Outdir { packages } => {
+            info!("Executing outdir command for packages: {:?}", packages);
+            if let Err(e) = outdir_logic::run_outdir(&config, &packages) {
+                error!("Outdir failed: {}", e);
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/outdir_logic.rs
+++ b/src/outdir_logic.rs
@@ -1,0 +1,26 @@
+use anyhow::{Result, anyhow};
+use log::info;
+
+use crate::config::Config;
+
+pub fn run_outdir(config: &Config, package_names: &[String]) -> Result<()> {
+    if package_names.is_empty() {
+        return Err(anyhow!("No packages specified for the 'outdir' command."));
+    }
+
+    info!("Printing output directories for packages: {:?}", package_names);
+
+    for package_name in package_names {
+        let normalized_name = package_name.trim_end_matches('/');
+
+        let package_build_dir = config.get_package_build_dir(normalized_name);
+        println!("{}", package_build_dir.display());
+
+        // Optionally, print install directory if configured, though `outdir` typically refers to build output
+        // if let Some(package_install_dir) = config.get_package_install_dir(normalized_name) {
+        //     println!("Install dir for {}: {}", normalized_name, package_install_dir.display());
+        // }
+    }
+
+    Ok(())
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,115 @@
+use anyhow::{Context, Result, anyhow};
+use log::{debug, error, info};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::fs;
+use glob::glob;
+
+/// Runs a command and checks its exit status.
+pub fn run_command(mut command: Command, description: &str) -> Result<()> {
+    debug!("Running command for {}: {:?}", description, command);
+    let status = command
+        .status()
+        .with_context(|| format!("Failed to execute command for {}", description))?;
+
+    if !status.success() {
+        error!(
+            "Command for {} failed with status: {}",
+            description, status
+        );
+        Err(anyhow!("Command failed: {}", description))
+    } else {
+        info!("Successfully executed command for {}", description);
+        Ok(())
+    }
+}
+
+/// Identifies CMake-based project directories within a given source directory.
+/// Optionally excludes a specific path (e.g., rocm-cmake itself).
+pub fn find_cmake_projects(source_dir: &Path, exclude_path: Option<&Path>) -> Result<Vec<PathBuf>> {
+    debug!("Searching for CMake projects in: {} (excluding {:?})", source_dir.display(), exclude_path);
+    let mut projects = Vec::new();
+    
+    // Search for CMakeLists.txt in immediate subdirectories
+    for entry in fs::read_dir(source_dir)
+        .with_context(|| format!("Failed to read source directory: {}", source_dir.display()))? 
+    {
+        let entry = entry.with_context(|| "Failed to read directory entry")?;
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(ex_path) = exclude_path {
+                if path == ex_path {
+                    debug!("Skipping excluded path: {}", path.display());
+                    continue;
+                }
+            }
+            if path.join("CMakeLists.txt").is_file() {
+                debug!("Found CMake project: {}", path.display());
+                projects.push(path);
+            } else {
+                // Also check for common project subdirectories like 'src' if CMakeLists.txt is not in root
+                // This is a simple heuristic and might need refinement
+                let src_cmakelists = path.join("src/CMakeLists.txt");
+                if src_cmakelists.is_file() {
+                     debug!("Found CMake project (in src/): {}", path.display());
+                     projects.push(path); // Add the parent directory of src/
+                }
+            }
+        }
+    }
+
+    // Alternative: Use glob to find all CMakeLists.txt files and then get their parent directories.
+    // This can be more flexible but might pick up CMakeLists.txt in unexpected places if not careful.
+    // For now, sticking to direct subdirectories.
+    // Example using glob:
+    // let pattern = source_dir.join("**/CMakeLists.txt");
+    // for entry in glob(&pattern.to_string_lossy())? {
+    //     match entry {
+    //         Ok(path) => {
+    //             if let Some(parent_dir) = path.parent() {
+    //                 if parent_dir != source_dir { // Exclude top-level CMakeLists.txt if any
+    //                     if let Some(ex_path) = exclude_path {
+    //                         if parent_dir == ex_path { continue; }
+    //                     }
+    //                     if !projects.contains(&parent_dir.to_path_buf()) {
+    //                         projects.push(parent_dir.to_path_buf());
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //         Err(e) => error!("Glob error: {}", e),
+    //     }
+    // }
+
+
+    if projects.is_empty() {
+        info!("No CMake projects found in {}", source_dir.display());
+    }
+    Ok(projects)
+}
+
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum SelectedPurpose {
+    Build,
+    Clean,
+    Outdir,
+}
+
+/// Checks if a package should be processed based on the user's selection.
+/// If `selected_packages` is empty, it means "all packages" are implicitly selected.
+/// Otherwise, only packages explicitly listed are selected.
+pub fn copy_if_selected(selected_packages: &[String], package_name: &str, purpose: SelectedPurpose) -> bool {
+    if selected_packages.is_empty() {
+        debug!("No specific packages selected for {:?}, processing all (including '{}').", purpose, package_name);
+        return true; // No specific packages listed, so all are considered selected
+    }
+    let normalized_package_name = package_name.trim_end_matches('/');
+    let is_selected = selected_packages.iter().any(|s| s.trim_end_matches('/') == normalized_package_name);
+    if is_selected {
+        debug!("Package '{}' is selected for {:?}.", package_name, purpose);
+    } else {
+        debug!("Package '{}' is NOT selected for {:?}.", package_name, purpose);
+    }
+    is_selected
+}


### PR DESCRIPTION
This introduces a new Rust-based command-line tool to replace the shell script `tools/rocm-build/build_rocm-cmake.sh`.

The new tool, `rocm_cmake_builder` (source located in `tools/rocm-build/rust_rocm_cmake_builder/`), replicates the functionality of the original shell script, providing commands for building, cleaning, and obtaining output directory information for the rocm-cmake component.

Benefits of this Rust CLI include:
- Improved maintainability and readability.
- Type safety and more robust error handling.
- Better argument parsing via the clap crate.

This initial commit includes the source code for the Rust application. Further integration into the main ROCm build system (e.g., updating Makefiles to call this tool) can be addressed in subsequent changes.

The core functionalities covered are:
- Building rocm-cmake (debug and release).
- Cleaning build artifacts.
- Providing output directory paths for packages.
- Handling command-line arguments similar to the original script.