### PR TITLE
feat: Implement rocminfo-builder with core features

### DIFF
--- a/tools/rust-builders/rocminfo-builder/README.md
+++ b/tools/rust-builders/rocminfo-builder/README.md
@@ -1,17 +1,24 @@
 # rocminfo Builder (Rust) - `rocminfo-builder`
 
-`rocminfo-builder` is a command-line utility written in Rust designed to replace the functionality of the `build_rocminfo.sh` shell script. It handles the building, (eventual) packaging, and installation of the `rocminfo` utility.
+`rocminfo-builder` is a command-line utility written in Rust designed to replace the functionality of the `build_rocminfo.sh` shell script. It handles the building, packaging, and installation of the `rocminfo` utility.
 
-**Note:** This utility is currently in Phase 1 of development. It supports cleaning and basic build (configure and install) operations. Packaging, wheel creation, and other advanced features will be added in subsequent phases.
+**Note:** This utility is currently in Phase 3 of development. It supports cleaning, building (configure, build, install), packaging (deb/rpm), Python wheel creation (if `setup.py` exists), and querying output directories. Full replication of `rocm_cmake_params()` and `rocm_common_cmake_params()` from `compute_utils.sh` is still pending.
 
-## Phase 1 Features
+## Features
 
--   Cleaning of build directories and the installed `rocminfo` binary.
--   Configuration of `rocminfo` via CMake.
--   Building and installing `rocminfo` using CMake.
--   CLI arguments for specifying paths, build type (debug/release), library type (static/shared), ASan, GPU list, and job parallelism.
+-   Cleaning of build directories, configured package directories, and the installed `rocminfo` binary.
+-   Configuration of `rocminfo` via CMake, with support for various build options.
+-   Building and installing `rocminfo` using CMake, with parallel job execution.
+-   Packaging `rocminfo` into DEB and RPM packages using CPack (via CMake).
+-   Copying specified package types (deb, rpm, or all) to structured package directories.
+-   Building Python wheel packages via `python setup.py bdist_wheel` (if `setup.py` is present in source root), with output to `<build-dir>/wheelhouse/`.
+-   Querying output paths for specific package types (`--outdir-target`).
+-   Support for Address Sanitizer (ASan) via CMake flags (environment variable setup for ASan runtime is noted as pending full `compute_utils.sh` logic).
+-   Passing GPU list and CPack versioning information to CMake.
+-   CLI arguments for specifying source/build/package/install paths, build type (debug/release), library type (static/shared), package filtering, verbosity, and job control.
+-   Improved error reporting by showing output from failed external commands (CMake, Python).
 
-## Usage (Phase 1)
+## Usage
 
 ### Command-Line Arguments
 
@@ -35,7 +42,7 @@ rocminfo-builder [OPTIONS] --source-root <PATH>
     Defaults to `<source-root>/build/rocminfo-builder`.
 
 *   `--package-root <PATH>`:
-    Optional: Specify the root directory for future packages (not fully used for output in Phase 1, but directories might be created/cleaned).
+    Optional: Specify the root directory for packages.
     Defaults to `<source_root>/dist`.
 
 *   `--rocm-libpatch-version <VERSION>`:
@@ -56,7 +63,7 @@ rocminfo-builder [OPTIONS] --source-root <PATH>
     Enable Address Sanitizer. This will set `-DENABLE_ADDRESS_SANITIZER=ON` for CMake (assumption, actual flag might differ based on `rocminfo`'s CMake) and is intended to also set necessary environment variables for the build process.
 
 *   `-w, --wheel`:
-    Creates a Python wheel package (if applicable for `rocminfo`). (Functionality to be fully implemented in Phase 3).
+    Creates a Python wheel package using `python setup.py bdist_wheel` (if `setup.py` exists in `--source-root`). Output is to `<build-dir>/wheelhouse/`.
 
 *   `--gpu-list <LIST>`:
     Optional: Comma-separated list of GPUs to target (passed to CMake as `-DGPU_LIST=<LIST>`).
@@ -64,13 +71,21 @@ rocminfo-builder [OPTIONS] --source-root <PATH>
 *   `--jobs <N>`:
     Optional: Number of parallel jobs for the CMake build step (`--parallel N`).
 
+*   `--package-type <TYPE>`:
+    Optional: Specify packaging format to copy after CPack (e.g., "deb", "rpm", "all").
+    (Default: "all")
+
+*   `--outdir-target <PKG_TYPE>`:
+    Optional: Print path of output directory for specified package type (deb, rpm) and exit.
+    Example: `--outdir-target deb`
+
 *   `-v, --verbose`:
     Enable verbose logging.
 
 *   `-h, --help`: Print help information.
 *   `-V, --version`: Print version information.
 
-### Examples (Phase 1)
+### Examples
 
 1.  **Clean existing build artifacts and installed binary:**
     (Assuming `rocminfo` source is in `./rocm/rocminfo-src` and default install prefix is used)
@@ -88,6 +103,22 @@ rocminfo-builder [OPTIONS] --source-root <PATH>
     rocminfo-builder       --source-root /path/to/rocminfo-source       --install-prefix ./my-install-area       --release       --static-libs       --jobs 4       -v
     ```
 
+4.  **Build, package DEBs and RPMs, and create a wheel (if setup.py exists):**
+    ```bash
+    rocminfo-builder           --source-root /path/to/rocminfo-source           --package-type all           --wheel           -v
+    ```
+
+5.  **Get the output directory for DEB packages:**
+    ```bash
+    rocminfo-builder           --source-root /path/to/rocminfo-source           --outdir-target deb
+    ```
+    Output might be: `/path/to/rocminfo-source/dist/deb/rocminfo` (assuming default package_root)
+
+6.  **Build with Address Sanitizer and specific GPU list:**
+    ```bash
+    rocminfo-builder           --source-root /path/to/rocminfo-source           --address-sanitizer           --gpu-list "gfx900;gfx906"           -v
+    ```
+
 ## Build Instructions for `rocminfo-builder`
 
 To build this utility itself:
@@ -100,10 +131,17 @@ To build this utility itself:
     ```
     The compiled binary will be located at `target/release/rocminfo-builder`.
 
-## Development Notes (Phase 1)
+## Development Notes
 
--   This phase focuses on core `clean` and `build` (configure & install) logic.
--   Packaging (`cmake --build . --target package`), specific package file copying, `--outdir-target` functionality, and full `--wheel` creation are planned for later phases.
--   The CMake parameters from `get_rocm_cmake_params()` and `get_rocm_common_cmake_params()` are currently placeholders (empty). Full replication of the original script's logic from `compute_utils.sh` is a key remaining item.
--   ASan support currently sets a CMake flag; full environment variable setup (like `ASAN_OPTIONS`) via `compute_utils.sh`'s `set_asan_env_vars` needs to be replicated if specific options are required for child processes.
+-   The CMake parameters generated by `get_rocm_cmake_params()` and `get_rocm_common_cmake_params()` are currently placeholders (empty). Full replication of the original script's logic from `compute_utils.sh` is a key remaining item. This might affect build reproducibility if `rocminfo` relies on specific parameters from these functions.
+-   Address Sanitizer (`--address-sanitizer`):
+    -   Currently sets `-DENABLE_ADDRESS_SANITIZER=ON` (assumed flag name) for CMake.
+    -   Full replication of `compute_utils.sh:set_asan_env_vars` (which would set runtime environment variables like `ASAN_OPTIONS` for child processes like CTest) is pending.
+-   Python wheel support (`--wheel`):
+    -   Invokes `python setup.py bdist_wheel --dist-dir <build-dir>/wheelhouse/`.
+    -   Requires `python3` (or `python`) and `setuptools` in PATH.
+    -   Checks for `setup.py` in `--source-root`; skips wheel build if not found (with a verbose message).
+    -   The original `build_wheel` from `compute_utils.sh` might have additional logic for copying the wheel to a final packaging location; this is not yet implemented by the Rust tool.
+-   Error handling shows `stdout`/`stderr` from failed external commands.
+-   The tool relies on `cmake`, `python3` (or `python` if for wheel), and standard build tools to be in the system PATH.
 ```

--- a/tools/rust-builders/rocminfo-builder/src/main.rs
+++ b/tools/rust-builders/rocminfo-builder/src/main.rs
@@ -1,15 +1,15 @@
 use clap::Parser;
 use std::path::{Path, PathBuf};
-use anyhow::{Context, Result};
-use std::env; // For current_dir
+use anyhow::{Context, Result, anyhow}; // Ensure anyhow is imported for anyhow::anyhow!
+use std::env; 
 use std::fs; 
-use std::process::Command; // Added for running external commands
-use which::which; // Added to find cmake executable
+use std::process::Command; 
+use which::which; 
+use glob::glob; 
 
-// CliArgs struct (as defined in the previous step)
 /// Rust equivalent of the build_rocminfo.sh script.
 /// Handles building and packaging of the rocminfo utility.
-#[derive(Parser, Debug, Clone)] 
+#[derive(Parser, Debug, Clone)] // Added Clone
 #[command(author, version, about, long_about = None)]
 struct CliArgs {
     /// Path to the rocminfo source directory (replaces ROCMINFO_ROOT env var).
@@ -63,9 +63,13 @@ struct CliArgs {
     #[arg(long, value_name = "N")]
     jobs: Option<usize>,
 
+    /// Specify packaging format to copy (e.g. "deb", "rpm", "all").
+    #[arg(long, value_name = "TYPE", default_value = "all")] // Already present from previous step
+    package_type: String,
+
     /// Optional: Print path of output directory for specified package type (deb, rpm) and exit.
     #[arg(long)]
-    outdir_target: Option<String>, 
+    outdir_target: Option<String>, // New argument
 
     /// Enable verbose logging.
     #[arg(long, short = 'v', action = clap::ArgAction::SetTrue)]
@@ -90,6 +94,7 @@ struct AppConfig {
     wheel: bool,
     gpu_list_cmake: Option<String>, 
     jobs: Option<usize>, 
+    package_type_to_copy: String, 
     verbose: bool,
 }
 
@@ -137,6 +142,7 @@ impl AppConfig {
             wheel: args.wheel,
             gpu_list_cmake: args.gpu_list.map(|gpus| format!("-DGPU_LIST={}", gpus)),
             jobs: args.jobs,
+            package_type_to_copy: args.package_type.to_lowercase(),
             verbose: args.verbose,
         })
     }
@@ -187,14 +193,69 @@ fn handle_clean(config: &AppConfig) -> Result<()> {
 }
 
 fn get_rocm_cmake_params(_config: &AppConfig) -> Vec<String> {
-    // Placeholder - to be implemented based on compute_utils.sh
     Vec::new()
 }
 
 fn get_rocm_common_cmake_params(_config: &AppConfig) -> Vec<String> {
-    // Placeholder - to be implemented based on compute_utils.sh
     Vec::new()
 }
+
+fn copy_packages(config: &AppConfig) -> Result<()> {
+    if config.verbose {
+        println!("Copying packages based on package_type_to_copy: {}", config.package_type_to_copy);
+    }
+
+    let copy_deb = config.package_type_to_copy == "all" || config.package_type_to_copy == "deb";
+    let copy_rpm = config.package_type_to_copy == "all" || config.package_type_to_copy == "rpm";
+
+    if copy_deb {
+        fs::create_dir_all(&config.deb_package_dir)
+            .with_context(|| format!("Failed to create DEB package directory: {:?}", config.deb_package_dir))?;
+        let deb_pattern = config.build_dir.join("*.deb"); 
+        if config.verbose {
+            println!("Searching for DEB packages with pattern: {:?}", deb_pattern.to_string_lossy());
+        }
+        for entry in glob(&deb_pattern.to_string_lossy())? {
+            match entry {
+                Ok(path) => {
+                    let file_name = path.file_name().ok_or_else(|| anyhow!("Failed to get filename from {:?}", path))?;
+                    let dest_path = config.deb_package_dir.join(file_name);
+                    if config.verbose {
+                        println!("Copying {:?} to {:?}", path, dest_path);
+                    }
+                    fs::copy(&path, &dest_path)
+                        .with_context(|| format!("Failed to copy {:?} to {:?}", path, dest_path))?;
+                }
+                Err(e) => return Err(anyhow!("Error matching DEB package: {}", e)),
+            }
+        }
+    }
+
+    if copy_rpm {
+        fs::create_dir_all(&config.rpm_package_dir)
+            .with_context(|| format!("Failed to create RPM package directory: {:?}", config.rpm_package_dir))?;
+        let rpm_pattern = config.build_dir.join("*.rpm"); 
+        if config.verbose {
+            println!("Searching for RPM packages with pattern: {:?}", rpm_pattern.to_string_lossy());
+        }
+        for entry in glob(&rpm_pattern.to_string_lossy())? {
+            match entry {
+                Ok(path) => {
+                    let file_name = path.file_name().ok_or_else(|| anyhow!("Failed to get filename from {:?}", path))?;
+                    let dest_path = config.rpm_package_dir.join(file_name);
+                    if config.verbose {
+                        println!("Copying {:?} to {:?}", path, dest_path);
+                    }
+                    fs::copy(&path, &dest_path)
+                        .with_context(|| format!("Failed to copy {:?} to {:?}", path, dest_path))?;
+                }
+                Err(e) => return Err(anyhow!("Error matching RPM package: {}", e)),
+            }
+        }
+    }
+    Ok(())
+}
+
 
 fn handle_build(config: &AppConfig) -> Result<()> {
     if config.verbose {
@@ -205,7 +266,7 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     fs::create_dir_all(&config.build_dir)
         .with_context(|| format!("Failed to create build directory: {:?}", config.build_dir))?;
 
-    let cmake_exe = which("cmake").map_err(|e| anyhow::anyhow!("cmake executable not found in PATH: {}", e))?;
+    let cmake_exe = which("cmake").map_err(|e| anyhow!("cmake executable not found in PATH: {}", e))?;
     if config.verbose {
         println!("Found cmake executable at: {:?}", cmake_exe);
     }
@@ -216,35 +277,31 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     }
     let mut cmake_configure_cmd = Command::new(&cmake_exe);
     cmake_configure_cmd.current_dir(&config.build_dir);
-    cmake_configure_cmd.arg(&config.source_root); // Source directory
-    
-    // Add params from placeholder functions
+    cmake_configure_cmd.arg(&config.source_root); 
     cmake_configure_cmd.args(get_rocm_cmake_params(config));
     cmake_configure_cmd.args(get_rocm_common_cmake_params(config));
-
-    // Add core CMake arguments
     cmake_configure_cmd.arg(format!("-DCMAKE_BUILD_TYPE={}", config.build_type_cmake));
     cmake_configure_cmd.arg(format!("-DBUILD_SHARED_LIBS={}", config.build_shared_libs_cmake));
     cmake_configure_cmd.arg(format!("-DCMAKE_INSTALL_PREFIX={}", config.install_prefix.display()));
     cmake_configure_cmd.arg(format!("-DROCRTST_BLD_TYPE={}", config.rocrts_bld_type_cmake));
-    
-    // CPack version variables from original script
-    cmake_configure_cmd.arg("-DCPACK_PACKAGE_VERSION_MAJOR=1"); // Hardcoded in script
+    cmake_configure_cmd.arg("-DCPACK_PACKAGE_VERSION_MAJOR=1"); 
     cmake_configure_cmd.arg(format!("-DCPACK_PACKAGE_VERSION_MINOR={}", config.rocm_libpatch_version));
-    cmake_configure_cmd.arg("-DCPACK_PACKAGE_VERSION_PATCH=0"); // Hardcoded in script
-    
-    cmake_configure_cmd.arg("-DCMAKE_SKIP_BUILD_RPATH=TRUE"); // Hardcoded
-
+    cmake_configure_cmd.arg("-DCPACK_PACKAGE_VERSION_PATCH=0"); 
+    cmake_configure_cmd.arg("-DCMAKE_SKIP_BUILD_RPATH=TRUE"); 
     if let Some(ref gpu_list_param) = config.gpu_list_cmake {
         cmake_configure_cmd.arg(gpu_list_param);
     }
-
     if config.address_sanitizer_enabled {
         if config.verbose {
-            println!("Address sanitizer enabled. Setting CMake flag and environment variables for CMake process.");
+            println!("Address sanitizer enabled. Setting CMake flag. Environment variable setup for ASan runtime (e.g., ASAN_OPTIONS) is pending full details from compute_utils.sh:set_asan_env_vars.");
         }
-        cmake_configure_cmd.arg("-DENABLE_ADDRESS_SANITIZER=ON"); // Assumed CMake flag
-        // cmake_configure_cmd.env("ASAN_OPTIONS", "detect_leaks=0"); // Example
+        cmake_configure_cmd.arg("-DENABLE_ADDRESS_SANITIZER=ON"); // Assumed CMake flag for compilation
+
+        // TODO: Replicate compute_utils.sh:set_asan_env_vars if needed for child processes (e.g., CTest).
+        // This would involve using cmake_configure_cmd.env("ASAN_OPTIONS", "value") and for other commands too if they run tests.
+        // For example:
+        // cmake_configure_cmd.env("ASAN_OPTIONS", "detect_leaks=0:detect_stack_use_after_return=1");
+        // cmake_build_cmd.env("ASAN_OPTIONS", "detect_leaks=0:detect_stack_use_after_return=1"); // If CTest runs here
     }
     
     if config.verbose {
@@ -252,7 +309,7 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     }
     let configure_output = cmake_configure_cmd.output().with_context(|| "Failed to execute CMake configure command")?;
     if !configure_output.status.success() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "CMake configure command failed with status: {}.\nStderr:\n{}\nStdout:\n{}",
             configure_output.status, String::from_utf8_lossy(&configure_output.stderr), String::from_utf8_lossy(&configure_output.stdout)
         ));
@@ -277,7 +334,7 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     }
     let build_output = cmake_build_cmd.output().with_context(|| "Failed to execute CMake build command")?;
     if !build_output.status.success() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "CMake build command failed with status: {}.\nStderr:\n{}\nStdout:\n{}",
             build_output.status, String::from_utf8_lossy(&build_output.stderr), String::from_utf8_lossy(&build_output.stdout)
         ));
@@ -294,7 +351,7 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     let mut cmake_install_cmd = Command::new(&cmake_exe);
     cmake_install_cmd.current_dir(&config.build_dir);
     cmake_install_cmd.arg("--build").arg(".").arg("--target").arg("install");
-    if let Some(jobs) = config.jobs { // Original script uses $MAKEARG for install too
+    if let Some(jobs) = config.jobs { 
         cmake_install_cmd.arg("--parallel").arg(jobs.to_string());
     }
     if config.verbose {
@@ -302,7 +359,7 @@ fn handle_build(config: &AppConfig) -> Result<()> {
     }
     let install_output = cmake_install_cmd.output().with_context(|| "Failed to execute CMake install command")?;
     if !install_output.status.success() {
-        return Err(anyhow::anyhow!(
+        return Err(anyhow!(
             "CMake install command failed with status: {}.\nStderr:\n{}\nStdout:\n{}",
             install_output.status, String::from_utf8_lossy(&install_output.stderr), String::from_utf8_lossy(&install_output.stdout)
         ));
@@ -311,12 +368,100 @@ fn handle_build(config: &AppConfig) -> Result<()> {
         print!("CMake install stdout:\n{}", String::from_utf8_lossy(&install_output.stdout));
         if !install_output.stderr.is_empty() { eprintln!("CMake install stderr:\n{}", String::from_utf8_lossy(&install_output.stderr)); }
     }
+    
+    // CMake Package Step
+    if config.verbose {
+        println!("Running CMake package step...");
+    }
+    let mut cmake_package_cmd = Command::new(&cmake_exe);
+    cmake_package_cmd.current_dir(&config.build_dir);
+    cmake_package_cmd.arg("--build").arg(".").arg("--target").arg("package");
+    if let Some(jobs) = config.jobs {
+        cmake_package_cmd.arg("--parallel").arg(jobs.to_string());
+    }
+    if config.verbose {
+        println!("CMake package command: {:?}", cmake_package_cmd);
+    }
+    let package_output = cmake_package_cmd.output().with_context(|| "Failed to execute CMake package command")?;
+    if !package_output.status.success() {
+        return Err(anyhow!(
+            "CMake package command failed with status: {}.\nStderr:\n{}\nStdout:\n{}",
+            package_output.status, String::from_utf8_lossy(&package_output.stderr), String::from_utf8_lossy(&package_output.stdout)
+        ));
+    }
+    if config.verbose {
+        print!("CMake package stdout:\n{}", String::from_utf8_lossy(&package_output.stdout));
+        if !package_output.stderr.is_empty() { eprintln!("CMake package stderr:\n{}", String::from_utf8_lossy(&package_output.stderr)); }
+        println!("CMake package step completed successfully.");
+    }
 
-    println!("Build and install operations completed.");
-    // Packaging and other steps will be added in later phases.
+    copy_packages(config)?;
+
+    // Wheel building logic
+    if config.wheel {
+        if config.verbose {
+            println!("Wheel package creation requested for rocminfo.");
+        }
+        // The original script calls build_wheel "$ROCMINFO_BUILD_DIR" "$PROJ_NAME".
+        // This implies setup.py might be in ROCMINFO_SRC_ROOT or build_wheel handles paths.
+        // We'll assume setup.py is in config.source_root.
+
+        let python_exe = which("python3").or_else(|_| which("python"))
+            .map_err(|e| anyhow::anyhow!("python3 or python executable not found in PATH for wheel build: {}", e))?;
+        
+        if config.verbose {
+            println!("Found python executable at: {:?}", python_exe);
+            println!("Assuming setup.py is in {:?}", config.source_root);
+        }
+
+        let setup_py_path = config.source_root.join("setup.py");
+        if !setup_py_path.exists() {
+            // It's possible rocminfo doesn't have a setup.py.
+            // The original script's build_wheel might handle this.
+            // For now, we'll print a warning if verbose, or just skip.
+            if config.verbose {
+                println!("Warning: setup.py not found at {:?}. Skipping wheel build.", setup_py_path);
+            }
+            // Assuming it's not a fatal error if setup.py is missing for rocminfo
+        } else {
+            let mut wheel_cmd = Command::new(python_exe);
+            wheel_cmd.current_dir(&config.source_root); // Run setup.py from its location
+            wheel_cmd.arg("setup.py").arg("bdist_wheel");
+
+            // Define wheel output directory
+            let wheel_dist_dir = config.build_dir.join("wheelhouse");
+            fs::create_dir_all(&wheel_dist_dir)
+                .with_context(|| format!("Failed to create directory for wheel output: {:?}", wheel_dist_dir))?;
+            wheel_cmd.arg("--dist-dir").arg(&wheel_dist_dir);
+
+            if config.verbose {
+                println!("Executing wheel command: {:?}", wheel_cmd);
+            }
+
+            let wheel_output = wheel_cmd.output()
+                .with_context(|| format!("Failed to execute python setup.py bdist_wheel. Ensure python and setuptools are installed and setup.py exists at {:?}", config.source_root))?;
+            
+            if !wheel_output.status.success() {
+                return Err(anyhow::anyhow!(
+                    "Python wheel command failed with status: {}.\nStderr:\n{}\nStdout:\n{}",
+                    wheel_output.status, String::from_utf8_lossy(&wheel_output.stderr), String::from_utf8_lossy(&wheel_output.stdout)
+                ));
+            }
+
+            if config.verbose {
+                print!("Python wheel command stdout:\n{}", String::from_utf8_lossy(&wheel_output.stdout));
+                if !wheel_output.stderr.is_empty() { eprintln!("Python wheel command stderr:\n{}", String::from_utf8_lossy(&wheel_output.stderr)); }
+                println!("Python wheel(s) for rocminfo created successfully in {:?}", wheel_dist_dir);
+                // TODO: Original script's build_wheel might copy this to a final package location.
+            }
+        }
+    }
+    
+    println!("rocminfo-builder: Build operations (including packaging/wheel if requested) completed.");
     Ok(())
 }
 
+// New handle_outdir function
 fn handle_outdir(config: &AppConfig, pkg_to_print: &str) -> Result<()> {
     if config.verbose {
         println!("Outdir action selected for package type: {}", pkg_to_print);
@@ -329,8 +474,7 @@ fn handle_outdir(config: &AppConfig, pkg_to_print: &str) -> Result<()> {
             println!("{}", config.rpm_package_dir.display());
         }
         _ => {
-            // Corrected the anyhow! macro usage
-            return Err(anyhow::anyhow!("Invalid package type \"{}\" provided for --outdir-target. Use 'deb' or 'rpm'.", pkg_to_print));
+            return Err(anyhow!("Invalid package type \"{}\" provided for --outdir-target. Use 'deb' or 'rpm'.", pkg_to_print));
         }
     }
     Ok(())
@@ -343,20 +487,20 @@ fn main() -> Result<()> {
         println!("Raw CLI arguments: {:#?}", &cli_args); 
     }
     
-    let config = AppConfig::try_from_args(cli_args.clone()) // Clone cli_args for AppConfig
-        .with_context(|| "Failed to initialize application configuration")?;
+    // Handle --outdir-target action first, as it's an informational command that exits.
+    if let Some(ref pkg_to_print) = cli_args.outdir_target {
+        let temp_cli_args_for_outdir = cli_args.clone(); 
+        let config_for_outdir = AppConfig::try_from_args(temp_cli_args_for_outdir)?;
+        return handle_outdir(&config_for_outdir, pkg_to_print);
+    }
+    
+    let config = AppConfig::try_from_args(cli_args)?; 
 
     if config.verbose {
         println!("Resolved AppConfig: {:#?}", &config);
         if config.address_sanitizer_enabled {
-             println!("Note: --address-sanitizer active. ASan env vars and CMake flags will be applied during build.");
+             println!("Note: --address-sanitizer active. ASan env vars and CMake flags will be applied during build if applicable.");
         }
-    }
-    
-    // Handle --outdir-target action first as it exits immediately
-    if let Some(ref pkg_to_print) = cli_args.outdir_target { 
-        // No need to create a separate config_for_outdir if AppConfig is already available
-        return handle_outdir(&config, pkg_to_print);
     }
     
     if config.clean {
@@ -365,8 +509,125 @@ fn main() -> Result<()> {
     
     handle_build(&config)?;
     
+    if config.wheel && config.verbose {
+        println!("Note: --wheel flag was specified, but rocminfo typically does not produce a Python wheel. This flag may have no effect for this component.");
+    }
+
     println!("rocminfo-builder (Rust) - Operation complete.");
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*; // Import items from the parent module (main.rs)
+    use std::fs as std_fs; // Renamed to avoid conflict with the module name if main.rs is in a directory named 'fs'
+
+    // Helper to create a basic CliArgs for testing AppConfig
+    fn basic_cli_args(source_root_path: PathBuf) -> CliArgs {
+        CliArgs {
+            source_root: source_root_path,
+            install_prefix: None,
+            build_dir: None,
+            package_root: None,
+            rocm_libpatch_version: "0".to_string(),
+            clean: false,
+            release: false,
+            static_libs: false,
+            address_sanitizer: false, // Corrected field name
+            wheel: false,
+            gpu_list: None,
+            jobs: None,
+            package_type: "all".to_string(), // Added this field
+            outdir_target: None,
+            verbose: false,
+        }
+    }
+
+    #[test]
+    fn test_app_config_defaults() {
+        let temp_dir = std::env::temp_dir();
+        let dummy_source_root = temp_dir.join("test_rocminfo_source_defaults");
+        std_fs::create_dir_all(&dummy_source_root).unwrap();
+
+        let mut cli_args = basic_cli_args(dummy_source_root.clone());
+        // Field name is 'address_sanitizer' in CliArgs
+        cli_args.address_sanitizer = false; 
+
+        let config_result = AppConfig::try_from_args(cli_args);
+        assert!(config_result.is_ok());
+        if let Ok(config) = config_result {
+            assert_eq!(config.source_root, dummy_source_root);
+            assert_eq!(config.build_dir, dummy_source_root.join("build").join("rocminfo-builder"));
+            let expected_package_root = dummy_source_root.join("dist");
+            assert_eq!(config.package_root, expected_package_root);
+            assert_eq!(config.install_prefix, expected_package_root.join("rocm"));
+            assert_eq!(config.deb_package_dir, expected_package_root.join("deb").join("rocminfo"));
+            assert_eq!(config.rpm_package_dir, expected_package_root.join("rpm").join("rocminfo"));
+            assert_eq!(config.build_type_cmake, "Debug");
+            assert_eq!(config.rocrts_bld_type_cmake, "debug");
+            assert_eq!(config.build_shared_libs_cmake, "ON");
+            assert!(!config.address_sanitizer_enabled);
+        }
+        
+        std_fs::remove_dir_all(&dummy_source_root).unwrap(); // Clean up
+    }
+
+    #[test]
+    fn test_app_config_release_flag() {
+        let temp_dir = std::env::temp_dir();
+        let dummy_source_root = temp_dir.join("test_rocminfo_source_release");
+        std_fs::create_dir_all(&dummy_source_root).unwrap();
+        
+        let mut cli_args = basic_cli_args(dummy_source_root.clone());
+        cli_args.release = true;
+        cli_args.address_sanitizer = false; 
+
+        let config = AppConfig::try_from_args(cli_args).unwrap();
+        assert_eq!(config.build_type_cmake, "RelWithDebInfo");
+        assert_eq!(config.rocrts_bld_type_cmake, "rel");
+        
+        std_fs::remove_dir_all(&dummy_source_root).unwrap(); // Clean up
+    }
+
+    #[test]
+    fn test_app_config_static_libs_flag() {
+        let temp_dir = std::env::temp_dir();
+        let dummy_source_root = temp_dir.join("test_rocminfo_source_static");
+        std_fs::create_dir_all(&dummy_source_root).unwrap();
+
+        let mut cli_args = basic_cli_args(dummy_source_root.clone());
+        cli_args.static_libs = true;
+        cli_args.address_sanitizer = false;
+
+        let config = AppConfig::try_from_args(cli_args).unwrap();
+        assert_eq!(config.build_shared_libs_cmake, "OFF");
+
+        std_fs::remove_dir_all(&dummy_source_root).unwrap(); // Clean up
+    }
+    
+    #[test]
+    fn test_app_config_custom_paths() {
+        let temp_dir = std::env::temp_dir();
+        let dummy_source_root = temp_dir.join("test_rocminfo_source_custom");
+        let custom_build_dir = temp_dir.join("custom_build");
+        let custom_package_root = temp_dir.join("custom_dist");
+        let custom_install_prefix = temp_dir.join("custom_install");
+
+        std_fs::create_dir_all(&dummy_source_root).unwrap();
+        // No need to create custom_build_dir, custom_package_root, custom_install_prefix for AppConfig test itself
+
+        let mut cli_args = basic_cli_args(dummy_source_root.clone());
+        cli_args.build_dir = Some(custom_build_dir.clone());
+        cli_args.package_root = Some(custom_package_root.clone());
+        cli_args.install_prefix = Some(custom_install_prefix.clone());
+        cli_args.address_sanitizer = false; 
+
+        let config = AppConfig::try_from_args(cli_args).unwrap();
+        assert_eq!(config.build_dir, custom_build_dir);
+        assert_eq!(config.package_root, custom_package_root);
+        assert_eq!(config.install_prefix, custom_install_prefix);
+        
+        std_fs::remove_dir_all(&dummy_source_root).unwrap(); // Clean up
+    }
+}
 ```


### PR DESCRIPTION
This commit provides a comprehensive Rust implementation of `rocminfo-builder`, a utility designed to replace `tools/rocm-build/build_rocminfo.sh`. It includes work from conceptual Phases 1, 2, and most of Phase 3.

Key Features:
- Full project setup in `tools/rust-builders/rocminfo-builder`.
- Extensive CLI argument parsing (`clap`) for options mirroring the shell script: paths (source, build, package, install), build controls (clean, release, static, ASan, wheel), CPack versioning, GPU list, job parallelism.
- `AppConfig` for robust configuration and path resolution.
- Actions implemented:
  - `clean`: Removes build/package artifacts and installed binary.
  - `build`:
    - Sets up ASan CMake flag if requested.
    - Configures `rocminfo` using CMake with various options. (Placeholders exist for `rocm_cmake_params` and `rocm_common_cmake_params` pending details from `compute_utils.sh`).
    - Compiles and installs `rocminfo` (`cmake --build . --target install`).
    - Creates DEB/RPM packages (`cmake --build . --target package`).
    - Copies packages to structured directories based on `--package-type`.
    - Builds Python wheel if `--wheel` is specified and `setup.py` exists.
  - `outdir`: Prints paths to package output directories.
- Dispatch logic in `main` to handle different actions and argument conflicts.
- Improved error handling: Captures and displays stdout/stderr from failed external commands (CMake, Python).
- Basic unit tests for `AppConfig` logic.
- Comprehensive `README.md` detailing all features, CLI arguments, usage examples, and development status.

The primary remaining work for full functional parity with the shell script is the implementation of CMake parameter generation functions (`get_rocm_cmake_params`, `get_rocm_common_cmake_params`) and any specific ASan environment variables from `compute_utils.sh`.

Output: