### PR TITLE
feat: Add support for .env file for environment variable configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 use env_logger::Env;
-use log::{info, error};
+use log::{info, error, debug, warn}; // Added debug and warn
+use dotenvy; // Added dotenvy
 
 mod build_logic;
 mod clean_logic;
@@ -12,10 +13,26 @@ mod utils;
 use config::{Cli, Commands, Config};
 
 fn main() -> Result<()> {
+    let dotenv_result = dotenvy::dotenv();
+
     let cli = Cli::parse();
 
     let default_log_level = if cli.verbose { "debug" } else { "info" };
     env_logger::Builder::from_env(Env::default().default_filter_or(default_log_level)).init();
+
+    // Log .env loading status after logger is initialized
+    match dotenv_result {
+        Ok(path) => {
+            info!("Loaded environment variables from: {}", path.display());
+        }
+        Err(e) => {
+            if e.is_io() && e.as_io_error().map_or(false, |io_err| io_err.kind() == std::io::ErrorKind::NotFound) {
+                debug!(".env file not found or not readable. Using system/shell environment variables only for initial setup.");
+            } else {
+                warn!("Failed to load .env file: {}. Using system/shell environment variables only for initial setup.", e);
+            }
+        }
+    }
 
     let config = match Config::from_cli(cli.clone()) {
         Ok(cfg) => cfg,


### PR DESCRIPTION
This commit introduces support for loading environment variables from a `.env` file located in the current working directory when the program starts.

Key changes:

1.  **Integrate `dotenvy` Crate:**
    - The `dotenvy` crate is used to load the `.env` file. (Note: This commit assumes `dotenvy = "0.15"` or similar has been added to the `[dependencies]` section of `Cargo.toml`).

2.  **.env File Loading at Startup:**
    - In `src/main.rs`, `dotenvy::dotenv()` is called at the very beginning of the `main()` function.
    - This allows variables defined in the `.env` file (e.g., `RUST_LOG`, `ROCM_CMAKE_PATH`) to be available for the program's execution.
    - Variables from `.env` will NOT override variables already present in the shell environment.

3.  **Logging:**
    - After the main logger is initialized (respecting `RUST_LOG` which could come from `.env`), the program now logs the status of the `.env` file loading: - An INFO message if `.env` was found and loaded, showing its path. - A DEBUG message if `.env` was not found. - A WARN message if `.env` was found but an error occurred during loading or parsing.

This feature provides a convenient way for you to manage project-specific environment variables without needing to export them in your shell.